### PR TITLE
implement site sync to app functionality

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -47,13 +47,7 @@ class CreateNewUser implements CreatesNewUsers
                 $site_team_id=config('constants.PRASSO_TEAM_ID');
                 //get the team from the site
                 if ($site->supports_registration) {
-                    $teamsite = TeamSite::where('site_id', $site->id)->first();
-                    if ($teamsite == null)
-                    {
-                        Log::error('TeamSite not found for site: ' . $site->id);
-                        $teamsite = TeamSite::where('site_id', $site_team_id)->first();
-                    }
-                    $team = Team::where('id', $teamsite->team_id)->first();
+                    $team = $site->teamFromSite();
                     $site_team_id = $team->id;
                     $team->users()->attach(
                         $user,

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -143,7 +143,6 @@ class AuthController extends BaseController
             $success['pn_token'] = $user->pn_token;
             $success['thirdPartyToken'] = '';
             
-            info('record_login'.json_encode($success));
             return $this->sendResponse($success, 'User has logged in.');
         } 
         else{ 
@@ -209,7 +208,7 @@ class AuthController extends BaseController
         }
       $token = $user->personalAccessToken? $user->personalAccessToken->token : null;
       $app_data = $this->appsService->getAppSettingsBySite($this->site, $user,$token);
-        $app_data = $this->appsService->getAppSettingsBySite($this->site, $user,$token);
+      info('getAppSettings'.json_encode($app_data));
 
         return $app_data;
 

--- a/app/Http/Middleware/UserPageAccess.php
+++ b/app/Http/Middleware/UserPageAccess.php
@@ -55,7 +55,6 @@ class UserPageAccess
         }
         else
         {
-          info('authorized user');
           \Auth::login($user);
         }
         return true;

--- a/app/Models/Apps.php
+++ b/app/Models/Apps.php
@@ -30,18 +30,20 @@ class Apps extends Model
         ->orderBy('sort_order');
     }
 
-    // for app users that have either instructor or admin, will exclude subscribepage links
+    // for app users that have either instructor or admin
     public function instructorroletabs()
     {
-        info('instructorroletabs');
-
         return $this->hasMany(\App\Models\Tabs::class, "app_id", "id")
-        ->where("team_role","=", config('constants.INSTRUCTOR'))
-        ->orWhere(function($query) 
+        ->where(function($query) 
         {
-           $query->where("team_role","=", null)
-           ->where('restrict_role',"=",false);
+            $query->where("team_role","=", config('constants.INSTRUCTOR'))
+            ->orWhere(function($query) 
+            {
+                $query->where("team_role","=", null)
+                ->where('restrict_role',"=",false);
+            });
         })
+        ->union($this->nullroletabs())
         ->orderBy('sort_order');
     }
 

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -51,6 +51,26 @@ class Site extends Model
         return $this->hasMany(\App\Models\SiteMedia::class, "fk_site_id", "id");
     }
 
+    public function teams(){
+        return $this->hasMany(\App\Models\TeamSite::class, "site_id", "id")
+            ->with('team');
+    }
+
+    public function app()
+    {
+        return $this->hasOne(Apps::class);
+    }
+ 
+    public function sitePages()
+    {
+        return $this->hasMany(\App\Models\SitePages::class, "fk_site_id", "id");
+    }
+
+    public function getApp()
+    {
+        return optional($this->app)->id;
+    }
+    
     public static function getClient( $host) 
     {
         if ($host == null)
@@ -148,12 +168,6 @@ class Site extends Model
             $dashboardpage->save();
         }
     }
-    // a function to get the site pages for this site
-    public function getSitePages()
-    {
-        $sitepages = SitePages::where('fk_site_id',$this->id)->get();
-        return $sitepages;
-    }
 
     private function user_is_admin(){
         $is_admin_for_site =  Auth::user() !=null && ( Auth::user()->isInstructor() || Auth::user()->isThisSiteTeamOwner($this->id) );
@@ -162,7 +176,7 @@ class Site extends Model
 
     public function getSiteMapList($current_page = null)
     {
-        $sitepages = $this->getSitePages();
+        $sitepages = $this->sitePages();
         $sitemap = array();
         foreach ($sitepages as $page)
         {
@@ -253,4 +267,15 @@ class Site extends Model
         $logo_image = config('constants.CLOUDFRONT_ASSET_URL') . config('constants.APP_LOGO_PATH') .'logos-'.$this->id.'/'. $photo->hashName();
         return $logo_image;
     }
+
+    public function teamFromSite(){
+       //get the team from the site
+    $teamSite = $this->teams()->first();
+    if ($teamSite == null) {
+        Log::error('TeamSite not found for site: ' . $this->id);
+        $teamSite = TeamSite::where('site_id', 1)->first();
+    }
+    return optional($teamSite)->team;
+    }
 }
+

--- a/app/Models/SitePages.php
+++ b/app/Models/SitePages.php
@@ -18,6 +18,11 @@ class SitePages extends Model
         'fk_site_id', 'section', 'title', 'description', 'url','headers','masterpage','template','style','login_required','user_level','where_value'
     ];
     
+    public function site()
+    {
+        return $this->belongsTo(Site::class, 'fk_site_id');
+    }
+
     public function site_page_data(){
         return $this->hasMany(\App\Models\SitePageData::class, "fk_site_page_id", "id");
     }

--- a/app/Models/Tabs.php
+++ b/app/Models/Tabs.php
@@ -47,7 +47,7 @@ class Tabs extends Model
 
   //  It's hasOne($related, $foreignKey, $localKey)
     public function team_role() {
-        return $this->hasOne(UserRole::class, 'team_role', 'id');
+        return optional($this->hasOne(UserRole::class, 'team_role', 'id'));
     }
 
 

--- a/app/Services/AppSyncService.php
+++ b/app/Services/AppSyncService.php
@@ -1,0 +1,50 @@
+<?php
+namespace App\Services;
+
+use App\Models\Apps;
+use App\Models\Site;
+use App\Models\SitePages;
+use App\Models\Tabs;
+
+class AppSyncService
+{
+    public function syncSelectedSitePagesToApp(Site $site, Apps $app, array $selectedPages)
+    {
+
+        if ($app == null)
+        {
+            $app = new Apps();
+            $team = $site->teamFromSite($site->id);
+            $app->team_id = $team->id;
+            $app->appicon = $site->logo_image;
+            $app->app_name = $site->site_name;
+            $app->page_title = $site->site_name;
+            $app->page_url = $site->site_name;
+            $app->sort_order = '1';
+
+            $newApp = $app->toArray();
+            $app::create($newApp);
+        }
+        // Add each selected site page as a tab to the app
+        $index = 0;
+        foreach ($selectedPages as $page) {
+            $sitePage = collect($site->sitePages)->firstWhere('id', $page);
+            if (!$sitePage) {
+                throw new \Exception("Site page not found: $page");
+            }
+            $tab = Tabs::make();
+            $tab->page_title = $sitePage->title;
+            $tab->page_url = '/page/'.$sitePage->section; 
+            $tab->app_id = $app->id;  
+            $tab->sort_order = $index++; 
+            $tab->parent = 0; 
+            $tab->icon = 'beach_access';
+            $tab->request_header = '{"Authorization":"Bearer [USER_TOKEN]"}';
+            $tab->restrict_role = $sitePage->user_level;
+                    
+            $tab->save();
+        }
+
+    }
+}
+?>

--- a/config/database.php
+++ b/config/database.php
@@ -8,15 +8,20 @@ return [
 
     'connections' => [
         
-        
-        'sqlite' => [
-            'driver' => 'sqlite',
-            'url' => env('DATABASE_URL'),
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+        'testing' => [
+            'driver' => 'mysql',
+            'host' => env('DB_TEST_HOST', '127.0.0.1'),
+            'port' => env('DB_TEST_PORT', '3306'),
+            'database' => env('DB_TEST_DATABASE', 'forge'),
+            'username' => env('DB_TEST_USERNAME', 'forge'),
+            'password' => env('DB_TEST_PASSWORD', ''),
+            'unix_socket' => env('DB_TEST_SOCKET', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
-            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+            'strict' => true,
+            'engine' => null,
         ],
-
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DATABASE_URL'),
@@ -37,33 +42,6 @@ return [
             ]) : [],
         ],
 
-        'pgsql' => [
-            'driver' => 'pgsql',
-            'url' => env('DATABASE_URL'),
-            'host' => env('DB_HOST', '127.0.0.1'),
-            'port' => env('DB_PORT', '5432'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'username' => env('DB_USERNAME', 'forge'),
-            'password' => env('DB_PASSWORD', ''),
-            'charset' => 'utf8',
-            'prefix' => '',
-            'prefix_indexes' => true,
-            'schema' => 'public',
-            'sslmode' => 'prefer',
-        ],
-
-        'sqlsrv' => [
-            'driver' => 'sqlsrv',
-            'url' => env('DATABASE_URL'),
-            'host' => env('DB_HOST', 'localhost'),
-            'port' => env('DB_PORT', '1433'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'username' => env('DB_USERNAME', 'forge'),
-            'password' => env('DB_PASSWORD', ''),
-            'charset' => 'utf8',
-            'prefix' => '',
-            'prefix_indexes' => true,
-        ],
 
     ],
 

--- a/database/factories/AppsFactory.php
+++ b/database/factories/AppsFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Apps;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AppsFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Apps::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {   
+        return [
+            'team_id' =>  0,
+            'site_id'  =>  0,
+            'appicon' =>  $this->faker->name, 
+            'app_name' => $this->faker->name, 
+            'page_title' =>  $this->faker->name, 
+            'page_url' => $this->faker->name , 
+            'sort_order' =>  1, 
+   
+        ];
+    }
+}

--- a/database/factories/SiteFactory.php
+++ b/database/factories/SiteFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Site;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SiteFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Site::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'site_name' => $this->faker->name,
+            'host' => 'testsite.test',
+            'main_color' =>  '#000000',
+            'logo_image' => 'image.jpg' ,
+            'database' =>  'mysql',
+            'app_specific_js' =>  '',
+            'app_specific_css' =>  '',
+            'image_folder' =>  'testing',
+            'favicon' =>  'favicon.ico',
+            'description' =>  'created for unit tests',
+            'supports_registration' =>  1,
+            'subteams_enabled' => 1
+        ];
+    }
+}

--- a/database/factories/SitePagesFactory.php
+++ b/database/factories/SitePagesFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SitePages;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SitePagesFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SitePages::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->name,
+            'fk_site_id' => false,
+            'section' => 'testsection',
+            'description' => $this->faker->phoneNumber,
+            'url' => 'testSitePages.test',
+            'headers' =>  'Authorization: BearerToken',
+            'masterpage' => '' ,
+            'template' =>  '',
+            'style' =>  '',
+            'login_required' =>  1,
+            'user_level' =>  0,
+        ];
+    }
+}

--- a/resources/views/apps/show.blade.php
+++ b/resources/views/apps/show.blade.php
@@ -13,7 +13,7 @@
        
 <section class="text-gray-700 body-font">
    
-    <div class="container px-8 pt-20 pb-24 mx-auto lg:px-4">
+    <div class="container  pt-20 pb-24 mx-auto px-4">
         <div class="shadow overflow-hidden sm:rounded-md">
             <div class="p-6 bg-white col-span-6">
                 <div class="flex flex-col w-full mb-12 text-left lg:text-center">
@@ -29,9 +29,9 @@
             
                     <x-teams-layout :selectedteam="$user->currentTeam->id" :teams="$teams" />
                 </div>
-                <div class="flex flex-col w-full p-5 mx-auto m-5 border rounded-lg l md:w-1/2 md:ml-auto md:mt-0">
+                <div class="flex flex-col w-full p-5 mx-auto m-5 border rounded-lg l ">
                 <div class="p-6 bg-white col-span-6">
-                <div class="max-w-xl text-sm text-gray-600" >
+                <div class="text-sm text-gray-600" >
                     <span class="mt-5 float-right ">  <a href="{{ route('apps.edit',['teamid' => $teams[0]['id'], 'appid' => 0])   }}">
                             <i class="material-icons md-36">playlist_add</i>
                         </a>

--- a/resources/views/components/apps-layout.blade.php
+++ b/resources/views/components/apps-layout.blade.php
@@ -1,6 +1,6 @@
 
 <div class="col-span-6">
-    <div class="max-w-xl text-sm bg-gray">
+    <div class="text-sm bg-gray">
         @foreach($apps as $app)
         @if (Auth::user()->id == 1 || $app['app_name'] == 'Prasso')
 

--- a/resources/views/livewire/apps/tab-info-form.blade.php
+++ b/resources/views/livewire/apps/tab-info-form.blade.php
@@ -41,22 +41,29 @@
 
     <!-- Icon -->
     <div class="col-span-6 sm:col-span-4">
-        <x-jet-label for="icon" value="{{ __('Icon') }}" />
+        <x-jet-label value="{{ __('Icon') }}" />
 
         <div class="multiselect">
-            <div class="selectBox" x-data="{ isShowing: false }" onclick="showRadios()">
-                <select  class='border-2 border-indigo-600/100 p-2'>
-                    <option>Select an icon</option>
-                </select>
-                <div class="overSelect"></div>
-            </div>
-            <div id="checkboxes">
+        <div class="selectBox" x-data="{ isShowing: false }" onclick="showRadios()">
+            <select class='border-2 border-indigo-600/100 p-2' wire:model.defer="tabdata.icon">
+                <option value="">Select an icon</option>
                 @foreach($icondata as $name)
-                <label for="{{ $name }}">
-                    <input x:model="selectedIcon" onclick="showRadios()" type="radio" value="{{ $name }}" wire:model.defer="tabdata.icon"  name="icon" /><i class="material-icons md-36">{{ $name }}</i> {{ $name }}</label>
+                    <option value="{{ $name }}" @if($tabdata['icon'] == $name) selected @endif>
+                        {{ $name }}
+                    </option>
                 @endforeach
-            </div>
+            </select>
+            <div class="overSelect"></div>
         </div>
+        <div id="checkboxes">
+            @foreach($icondata as $name)
+                <label>
+                    <input x:model="selectedIcon" onclick="showRadios()" type="radio" value="{{ $name }}" wire:model.defer="tabdata.icon" name="icon" />
+                    <i class="material-icons md-36">{{ $name }}</i> {{ $name }}
+                </label>
+            @endforeach
+        </div>
+    </div>
         <div style="float:right; margin-left:2px;color:brown;" id="selectedIcon"></div>
         
         <x-jet-input-error for="icon" class="mt-2" />

--- a/resources/views/livewire/site-editor.blade.php
+++ b/resources/views/livewire/site-editor.blade.php
@@ -11,7 +11,9 @@
             @if($isOpen)
                 @include('sites.create-or-edit')
             @endif          
-
+            @if($showSyncDialog)
+                @include('sites.sync-site-and-app')
+            @endif
             <table class="table-fixed w-full">
                 <thead>
                     <tr class="bg-gray-100">
@@ -29,12 +31,15 @@
                         <td class="border px-4 py-2 overflow-hidden">{{ $site->site_name }}</td>
                         <td class="border px-4 py-2 overflow-hidden">{{ $site->host }}</td>
                         <td class="border px-4 py-2"><img src="{{ $site->logo_image }}" class="block h-9 w-auto" /></td>
-                        <td class="border px-4 py-2">
-                        <button wire:click="edit({{ $site->id }})" class=" py-2 px-3 "> <i class="material-icons md-36">mode_edit</i></button>
+                        <td class="border px-2 py-2">
+                        <button wire:click="edit({{ $site->id }})" class="py-2 px-3 "> <i class="material-icons md-36">mode_edit</i></button>
                         <a href="/sitepages/{{ $site->id }}" ><i class="material-icons md-36 text-black ">list</i></a>
                         <button onclick="return window.confirm('Are you sure you want to delete this site?')" wire:click="delete({{ $site->id }})" class="ml-3 py-2 px-3 rounded"><i class="material-icons md-36">delete_forever</i></button>
+                       
+                        <button wire:click="showTheSyncDialog({{ $site->id }})" class="py-2 px-3"><i class="material-icons md-36">sync</i></button>
+                        
                         @if ($site->livestream_settings != null)
-                        <a href="/site/{{ $site->id }}/livestream-mtce" class="ml-3 py-2 px-3 rounded"><i class="material-icons md-36">live_tv</i></a>
+                        <a href="/site/{{ $site->id }}/livestream-mtce" class="py-2 px-3"><i class="material-icons md-36">live_tv</i></a>
                         @endif
                     </td>
                     </tr>

--- a/resources/views/sites/sync-site-and-app.blade.php
+++ b/resources/views/sites/sync-site-and-app.blade.php
@@ -1,0 +1,32 @@
+
+
+<div class="fixed z-10 inset-0 overflow-y-auto ease-out duration-400">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+        <div class="fixed inset-0 transition-opacity">
+            <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+        </div>
+            <!-- This element is to trick the browser into centering the modal contents. -->
+            <span class="hidden sm:inline-block sm:align-middle sm:h-screen"></span>?
+    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+<div class="text-lg text-center font-bold py-2">Sync Pages to App</div>
+    <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        @if($errors->any())
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+            {!! implode('', $errors->all('<div>:message</div>')) !!}
+        </div>
+        @endif
+        <div class="mb-4">
+        <form wire:submit.prevent="syncAppToSite">
+            @foreach ($sitePages as $page)
+                <div>
+                    <input type="checkbox" wire:model="selectedPages" value="{{ $page->id }}">
+                    <label>{{ $page->title }}</label>
+                </div>
+            @endforeach
+
+            <button class="teambutton rounded" wire:click"syncAppToSite">Sync</button>
+            <button type="button" wire:click="hideSyncDialog">Cancel</button>
+        </form>
+    </div>
+</div>
+            </div></div>

--- a/tests/Unit/SiteEditorTest.php
+++ b/tests/Unit/SiteEditorTest.php
@@ -1,0 +1,47 @@
+<?php
+use App\Models\Apps;
+use App\Models\Site;
+use App\Models\SitePages;
+use App\Http\Livewire\SiteEditor;
+use App\Services\AppSyncService;
+use App\Models\Team;
+use Tests\TestCase;
+
+class SiteEditorTest extends TestCase
+{
+
+    /** @test */
+    public function it_can_sync_selected_site_pages_to_an_app_as_tabs()
+    {
+        $team = Team::factory()->create();
+        
+        // Create a site
+        $site = Site::factory()->create();
+
+        // Create some site pages
+        $sitePages = SitePages::factory()->count(3)->create([
+            'fk_site_id' => $site->id,
+        ]);
+
+        // Create an app
+        $app = Apps::factory()->create([
+            'site_id' => $site->id,
+            'team_id' =>  $team->id,
+        ]);
+
+        // Select some site pages to sync to the app
+        $selectedPages = $sitePages->take(2)->pluck('id')->toArray();
+        // Call the syncAppToSite method
+        $appSyncService = new AppSyncService();
+        $siteEditor = new SiteEditor($appSyncService);
+        $siteEditor->showTheSyncDialog($site->id);
+        $siteEditor->selectedPages = $selectedPages;
+        $siteEditor->syncAppToSite();
+        
+        // Assert that the selected site pages were added as tabs to the app
+        $this->assertCount(2, $app->tabs);
+        $this->assertEquals($sitePages->firstWhere('id', $selectedPages[0])->title, $app->tabs[0]->page_title);
+        $this->assertEquals($sitePages->firstWhere('id', $selectedPages[1])->title, $app->tabs[1]->page_title);
+    }
+}
+?>

--- a/tests/Unit/test  connections .php
+++ b/tests/Unit/test  connections .php
@@ -1,0 +1,21 @@
+'connections' => [
+
+    // ...
+
+    'testing' => [
+        'driver' => 'mysql',
+        'host' => env('DB_TEST_HOST', '127.0.0.1'),
+        'port' => env('DB_TEST_PORT', '3306'),
+        'database' => env('DB_TEST_DATABASE', 'forge'),
+        'username' => env('DB_TEST_USERNAME', 'forge'),
+        'password' => env('DB_TEST_PASSWORD', ''),
+        'unix_socket' => env('DB_TEST_SOCKET', ''),
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'prefix' => '',
+        'strict' => true,
+        'engine' => null,
+    ],
+
+    // ...
+]


### PR DESCRIPTION
This PR include changes to code that adds a new button to the site list for super admin useage. When clicked, functionality  shows site pages for the site in a checkbox list  and then allows the user to select site pages to sync to the app. 
When submitted, the syncAppToSite method of the SiteEditor class is called which saves the selected urls as tabs to the app so that they are available in the app editor.
a test is added which tests this functionality and asserts that the selected site pages were added as tabs to the app.